### PR TITLE
Repository class visibility

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.UnitOfWork/Repository.cs
+++ b/src/Microsoft.EntityFrameworkCore.UnitOfWork/Repository.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore {
     /// Represents a default generic repository implements the <see cref="IRepository{TEntity}"/> interface.
     /// </summary>
     /// <typeparam name="TEntity">The type of the entity.</typeparam>
-    internal class Repository<TEntity> : IRepository<TEntity> where TEntity : class {
+    public class Repository<TEntity> : IRepository<TEntity> where TEntity : class {
         private readonly DbContext _dbContext;
         private readonly DbSet<TEntity> _dbSet;
 

--- a/src/Microsoft.EntityFrameworkCore.UnitOfWork/project.json
+++ b/src/Microsoft.EntityFrameworkCore.UnitOfWork/project.json
@@ -37,11 +37,7 @@
     "Microsoft.EntityFrameworkCore.Relational": "1.1.0"
   },
   "frameworks": {
-    "net46": {
-
-    },
     "netstandard1.6": {
-
     }
   }
 }


### PR DESCRIPTION
Repository class was internal. I changed it to public. Without this notification, you cannot use or reuse this repository implementation in others projects.