### PR TITLE
Fix InvalidOperationException on SaveChangesAsync and transaction scope

### DIFF
--- a/src/UnitOfWork/UnitOfWork.cs
+++ b/src/UnitOfWork/UnitOfWork.cs
@@ -157,12 +157,12 @@ namespace Arch.EntityFrameworkCore.UnitOfWork
         /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous save operation. The task result contains the number of state entities written to database.</returns>
         public async Task<int> SaveChangesAsync(bool ensureAutoHistory = false, params IUnitOfWork[] unitOfWorks)
         {
-            using (var ts = new TransactionScope())
+            using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {
                 var count = 0;
                 foreach (var unitOfWork in unitOfWorks)
                 {
-                    count += await unitOfWork.SaveChangesAsync(ensureAutoHistory);
+                    count += await unitOfWork.SaveChangesAsync(ensureAutoHistory).ConfigureAwait(false);
                 }
 
                 count += await SaveChangesAsync(ensureAutoHistory);


### PR DESCRIPTION
I have experienced the following problem on invoking `SaveChangesAsync` with a single unit of work

```
System.InvalidOperationException: A TransactionScope must be disposed on the same thread that it was created. 
   at System.Transactions.TransactionScope.Dispose (System.Transactions.Local, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at Arch.EntityFrameworkCore.UnitOfWork.UnitOfWork`1+<SaveChangesAsync>d__12.MoveNext (Microsoft.EntityFrameworkCore.UnitOfWork, Version=3.1.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
```

The cause is that for some reason the compile forces the call to the SaveChangesAsync method with optional units of work.

By looking around (not so [around](https://stackoverflow.com/a/17527843/471213), it looks like that it is necessary to use another constructor of TransactionScope when using an async context.